### PR TITLE
Hide additional classes

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,6 +1,7 @@
 li.jobs-unified-top-card__job-insight--highlight,
 div.jobs-unified-top-card__primary-description > div > span:last-child,
-.tvm__text tvm__text--positive
+li.job-card-container__footer-item > strong,
+li.job-card-container__applicant-count
 {
   display: none !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change hides the applicant count in a few more places on the `/jobs` route. 

## Background
While browsing through LinkedIn with the extension, I noticed a few extra places where the applicant was visible. Namely, at the bottom of the page when viewing a specific job. (There were several cards listing similar jobs.) And at `/jobs` directly, where it was listed beside several roles. This hides it in those additional areas. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can follow the instructions for loading an unpacked extension in the [README](https://github.com/garnetred/hide-linkedin-applicants/blob/main/README.md)
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
After

<img width="267" alt="Screen Shot 2023-07-05 at 5 30 08 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/e91258e9-25a3-40bc-b274-bffbecdf2ffb">
<img width="538" alt="Screen Shot 2023-07-05 at 5 29 19 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/c9d9e86a-dd64-4eda-b071-ac0309a62cea">
<img width="576" alt="Screen Shot 2023-07-05 at 5 29 11 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/2137deaa-dd3b-4434-9faa-0270eb359ccb">


<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
