### PR TITLE
Feat/hide count job page

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,7 +1,8 @@
 li.jobs-unified-top-card__job-insight--highlight,
 div.jobs-unified-top-card__primary-description > div > span:last-child,
 li.job-card-container__footer-item > strong,
-li.job-card-container__applicant-count
+li.job-card-container__applicant-count,
+.jobs-unified-top-card__applicant-count
 {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I noticed I was still seeing the applicant count on the search page for any jobs open in the main viewer, so I went ahead an updated the code to hide this. 

<!--- Describe your changes in detail -->

## Background
This browser extension hides the applicant count by accessing the HTML element and removing it from the DOM using CSS. The class for the applicant count on one page changed, resulting in the browser extension no longer being able to remove it from the DOM. I updated the class used as the css selector to encompass this change. 
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can git clone the repo and load the repo unpacked using the instructions in the [README](https://github.com/garnetred/hide-linkedin-applicants/blob/main/README.md). 
From there, you can search for a specific job. After clicking on a job, you should not see the applicant count at the top right.

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

Before:
<img width="625" alt="Screen Shot 2023-07-11 at 5 38 16 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/523d7efe-e93b-4a6d-a8ad-ae27976c7180">


After:
<img width="621" alt="Screen Shot 2023-07-11 at 5 37 59 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/18cc5a79-c3ea-459c-9bbd-6328feb5d4c8">


<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
