### PR TITLE
Feat/hide count jobs view

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -2,7 +2,8 @@ li.jobs-unified-top-card__job-insight--highlight,
 div.jobs-unified-top-card__primary-description > div > span:last-child,
 li.job-card-container__footer-item > strong,
 li.job-card-container__applicant-count,
-.jobs-unified-top-card__applicant-count
+.jobs-unified-top-card__applicant-count,
+.jobs-unified-top-card__bullet
 {
   display: none !important;
 }

--- a/css/search.css
+++ b/css/search.css
@@ -2,8 +2,6 @@ li.jobs-unified-top-card__job-insight--highlight,
 div.jobs-unified-top-card__primary-description > div > span:last-child,
 li.job-card-container__footer-item > strong,
 li.job-card-container__applicant-count,
-.jobs-unified-top-card__applicant-count,
-.jobs-unified-top-card__bullet
-{
+.jobs-unified-top-card__applicant-count {
   display: none !important;
 }

--- a/css/view.css
+++ b/css/view.css
@@ -1,0 +1,4 @@
+.jobs-unified-top-card__subtitle-secondary-grouping
+  > .jobs-unified-top-card__bullet {
+  display: none !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
         "matches": [
         "*://www.linkedin.com/jobs/*"
       ],
-      "css": ["css/global.css"]
+      "css": ["css/search.css", "css/view.css"]
     }
 ],
   "host_permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "1.0.3",
+  "version": "0.0.3",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.3",
+  "version": "1.0.3",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,13 +1,22 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   const tabUrl = tab.url ?? tab.pendingUrl;
   if (
-    changeInfo.status === 'complete' &&
+    changeInfo.status === "complete" &&
     tabUrl &&
-    (tabUrl.includes('linkedin.com/feed') || tabUrl.includes('linkedin.com/in'))
+    tabUrl.includes("linkedin.com/jobs/search")
   ) {
     chrome.scripting.insertCSS({
       target: { tabId: tabId },
-      files: ['css/global.css'],
+      files: ["css/search.css"],
+    });
+  } else if (
+    changeInfo.status === "complete" &&
+    tabUrl &&
+    tabUrl.includes("linkedin.com/jobs/view")
+  ) {
+    chrome.scripting.insertCSS({
+      target: { tabId: tabId },
+      files: ["css/view.css"],
     });
   }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I noticed recently that I was still seeing the applicant count on the `linkedin.com/jobs/view` route. This updates the CSS to hide it. It also un-hides the job location.

<!--- Describe your changes in detail -->

## Background
This application works primarily on two routes - `www.linkedin.com/jobs/view` and `www.linkedin.com/jobs/search`. Multiple classes are reused from page to page. I noticed that the applicant count appeared at the former url but was hidden everywhere else - although it also was hiding the job location on the `jobs/search` route. 

I split the CSS into two separate files and am injecting different CSS files depending on the URL. This allowed me to use more complicated logic for the `jobs/view` route in order to hide just the applicant count and not the job location. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test this by cloning down the repo using `git clone.` 
You can navigate to chrome://extensions and choose developer mode. From there, you can load an unpacked extension and select the folder containing this codebase. 
Afterwards you can navigate to linkedin and search for a job. You should not see the applicant count on that page (`jobs/search`). You can click on a specific job title and, after being redirected to `jobs/views`, you should still not see the applicant count, although the location should be visible. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
After:
`www.linkedin.com/jobs/view/*`
<img width="386" alt="Screen Shot 2023-07-12 at 2 53 42 AM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/3f01e52d-1d14-40d6-a33f-e7797499523f">


<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
