### PR TITLE
Feat/update routes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,16 +1,6 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   const tabUrl = tab.url ?? tab.pendingUrl;
   if (
-    (changeInfo.status === "complete" &&
-      tabUrl &&
-      tabUrl.includes("linkedin.com/jobs/search")) ||
-    tabUrl.includes("linkedin.com/jobs/collections")
-  ) {
-    chrome.scripting.insertCSS({
-      target: { tabId: tabId },
-      files: ["css/search.css"],
-    });
-  } else if (
     changeInfo.status === "complete" &&
     tabUrl &&
     tabUrl.includes("linkedin.com/jobs/view")
@@ -18,6 +8,17 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     chrome.scripting.insertCSS({
       target: { tabId: tabId },
       files: ["css/view.css"],
+    });
+  } else if (
+    (changeInfo.status === "complete" &&
+      tabUrl &&
+      tabUrl.includes("linkedin.com/jobs/search")) ||
+    tabUrl.includes("linkedin.com/jobs/collections") ||
+    tabUrl.includes("linkedin.com/jobs")
+  ) {
+    chrome.scripting.insertCSS({
+      target: { tabId: tabId },
+      files: ["css/search.css"],
     });
   }
 });

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,9 +1,10 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   const tabUrl = tab.url ?? tab.pendingUrl;
   if (
-    changeInfo.status === "complete" &&
-    tabUrl &&
-    tabUrl.includes("linkedin.com/jobs/search")
+    (changeInfo.status === "complete" &&
+      tabUrl &&
+      tabUrl.includes("linkedin.com/jobs/search")) ||
+    tabUrl.includes("linkedin.com/jobs/collections")
   ) {
     chrome.scripting.insertCSS({
       target: { tabId: tabId },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I noticed a bug where the applicant count was visible on `jobs/collections` if you navigated there from `/jobs`. This change injects different CSS files depending on a longer list of routes that use the same class names. 

<!--- Describe your changes in detail -->

## Background
This change is necessary to continue hiding the applicant count throughout the site. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by git cloning the repo, loading it as an unpacked extension at `chrome://extensions` in developer mode, and navigating to Linkedin. You should click the 'jobs' icon in the navbar. From there, if you click on a job collection on a specific role you should not see an applicant count. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
