### PR TITLE
Update logic to hide applicants on jobs/collections page

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,7 +1,9 @@
-li.jobs-unified-top-card__job-insight--highlight,
+.jobs-unified-top-card__job-insight--highlight,
 div.jobs-unified-top-card__primary-description > div > span:last-child,
 li.job-card-container__footer-item > strong,
 li.job-card-container__applicant-count,
-.jobs-unified-top-card__applicant-count {
+.jobs-unified-top-card__applicant-count,
+.jobs-unified-top-card__subtitle-secondary-grouping
+  > .jobs-unified-top-card__bullet {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -10,10 +10,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
       files: ["css/view.css"],
     });
   } else if (
-    (changeInfo.status === "complete" &&
-      tabUrl &&
-      tabUrl.includes("linkedin.com/jobs/search")) ||
-    tabUrl.includes("linkedin.com/jobs/collections") ||
+    changeInfo.status === "complete" &&
+    tabUrl &&
     tabUrl.includes("linkedin.com/jobs")
   ) {
     chrome.scripting.insertCSS({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
I noticed today that job applicants were no longer hidden at the top of the `jobs/collections` page, so I updated the CSS classes. 
<!--- Describe your changes in detail -->

## Background
I think the CSS may have changed for the applicant count on the regular jobs/collection page. I updated the CSS accordingly so that number is hidden on the top right. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can git clone the repo and load an unpacked extension by following the instructions in the [README](https://www.github.com/garnetred/hide-linkedin-applicants/blob/main/). 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

After: 
<img width="1183" alt="Screen Shot 2023-07-15 at 4 03 27 AM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/9d1715e9-0a34-4057-9f5f-64f471784db9">

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
