### PR TITLE
Feat/hide premium ad

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -8,9 +8,9 @@ li.job-card-container__applicant-count,
   display: none !important;
 }
 
-span.tvm__text:not(:has(span)) {
+/* span.tvm__text:not(:has(span)) {
   display: none !important;
-}
+} */
 
 li.job-details-jobs-unified-top-card__job-insight--highlight:not(:has(button)) {
   display: none !important;

--- a/css/search.css
+++ b/css/search.css
@@ -8,10 +8,6 @@ li.job-card-container__applicant-count,
   display: none !important;
 }
 
-/* span.tvm__text:not(:has(span)) {
-  display: none !important;
-} */
-
 li.job-details-jobs-unified-top-card__job-insight--highlight:not(:has(button)) {
   display: none !important;
 }

--- a/css/search.css
+++ b/css/search.css
@@ -13,5 +13,5 @@ span.tvm__text:not(:has(span)) {
 }
 
 li.job-details-jobs-unified-top-card__job-insight--highlight:not(:has(button)) {
-  display: none;
+  display: none !important;
 }

--- a/css/view.css
+++ b/css/view.css
@@ -5,12 +5,6 @@
 
 /* hides "see how you compare to x applicants" option next to reactivate premium button */
 
-/* .job-details-jobs-unified-top-card__job-insight--highlight:has(
-    .t-black--light
-  ) {
-  display: none !important;
-} */
-
 .job-details-jobs-unified-top-card__job-insight--highlight:has(div):has(
     div
   ):has(div):has(svg[data-test-icon="lightbulb-medium"]) {
@@ -18,7 +12,6 @@
 }
 
 /* hides applicant count at top of page next to company name and location */
-
 .tvm__text--neutral {
   display: none !important;
 }

--- a/css/view.css
+++ b/css/view.css
@@ -3,12 +3,22 @@
   display: none !important;
 }
 
-.job-details-jobs-unified-top-card__job-insight--highlight:has(
+/* hides "see how you compare to x applicants" option next to reactivate premium button */
+
+/* .job-details-jobs-unified-top-card__job-insight--highlight:has(
     .t-black--light
   ) {
   display: none !important;
+} */
+
+.job-details-jobs-unified-top-card__job-insight--highlight:has(div):has(
+    div
+  ):has(div):has(svg[data-test-icon="lightbulb-medium"]) {
+  display: none !important;
 }
 
-span.tvm__text:not(:has(span)) {
+/* hides applicant count at top of page next to company name and location */
+
+.tvm__text--neutral {
   display: none !important;
 }

--- a/css/view.css
+++ b/css/view.css
@@ -3,6 +3,12 @@
   display: none !important;
 }
 
+.job-details-jobs-unified-top-card__job-insight--highlight:has(
+    .t-black--light
+  ) {
+  display: none !important;
+}
+
 span.tvm__text:not(:has(span)) {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,10 +2,11 @@
   <body>
     <h2>Hide LinkedIn Applicants</h2>
     <p>
-      version: 0.0.7 |
+      version: 0.0.8 |
       <a
         href="https://github.com/garnetred/hide-linkedin-applicants"
         style="color: navy"
+        target="_blank"
         >github</a
       >
     </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change hides the text that says "See how your application compares to X applicants" on a specific job page. 

<!--- Describe your changes in detail -->

## Background
I noticed recently that the number of applicants wasn't being hidden on this page. I decided to refactor some of the CSS hiding elements to use the :has() pseudo-class more often since it seems to be more reliable than looking for chained css selectors. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by `git cloning` the repo, loading the unpacked extension while in developer mode in your browser, and navigating to LinkedIn. From there you can select a specific job posting until you land on a page with `linkedin.com/jobs/view` in the url. You should not see any mention of applicant numbers on that page. 

I also took some time to update `popup.html` to open the link to github in a new tab. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before
<img width="566" alt="Screen Shot 2024-02-10 at 3 48 21 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/228e5c28-3847-4991-818b-d937bfe8093f">

After
<img width="404" alt="Screen Shot 2024-02-10 at 3 59 33 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/450d7652-0fe1-4877-96ce-6850b1aabe97">

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
