### PR TITLE
Hide applicant count on jobs/search route

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,5 +1,7 @@
 .jobs-unified-top-card__job-insight--highlight,
-div.jobs-unified-top-card__primary-description > div > span:last-child,
+div.jobs-unified-top-card__primary-description-without-tagline
+  > div
+  > span:last-child,
 li.job-card-container__footer-item > strong,
 li.job-card-container__applicant-count,
 .jobs-unified-top-card__applicant-count,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This hides the applicant count next to the company name and location on the `jobs/search` route. 

<!--- Describe your changes in detail -->

## Background
I noticed that this was no longer being hidden because the class name had changed for the parent element, so this PR only updates the parent element. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
`git clone` down the repo, load the unpacked extension while in developer mode in your browser, then navigate to `linkedin.com/jobs`. If you click on any of the listed jobs, you will land on the `jobs/search` route. From there, you shouldn't see an applicant count. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
