### PR TITLE
Hide over 100 applicants message

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -3,6 +3,14 @@
   display: none !important;
 }
 
+/* hides "over 100 applicants" message at linkedin.com/jobs/collections */
+
+.job-details-jobs-unified-top-card__primary-description-container:has(div):has(
+    .tvm__text--neutral
+  ):last-child {
+  display: none !important;
+}
+
 /* hides "see how you compare to x applicants" option next to reactivate premium button on view page */
 
 .job-details-jobs-unified-top-card__job-insight--highlight:has(div):has(

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.1.0",
+  "version": "0.0.10",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LinkedIn Applicants</h2>
     <p>
-      version: 0.1.0 |
+      version: 0.0.10 |
       <a
         href="https://github.com/garnetred/hide-linkedin-applicants"
         style="color: navy"

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LinkedIn Applicants</h2>
     <p>
-      version: 0.0.9 |
+      version: 0.1.0 |
       <a
         href="https://github.com/garnetred/hide-linkedin-applicants"
         style="color: navy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
Fixes an issue where "over 100 applicants" still appeared at the top of each job on the right-hand side on `jobs/collections/` route. 
<!--- Describe your changes in detail -->

## Background
I noticed after merging #11 that when a job has over 100 applicants, that count is still visible. I went ahead and updated that here and commented the new CSS. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can load the unpacked extension after `git clone`-ing this branch. When you navigate to a job at this route, you shouldn't see any applicant counts. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before
<img width="608" alt="Screen Shot 2024-02-14 at 6 45 29 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/c6b812d4-8130-45a4-8364-6aa77237dbbf">

After
<img width="619" alt="Screen Shot 2024-02-14 at 6 45 06 PM" src="https://github.com/garnetred/hide-linkedin-applicants/assets/59572865/96ebd258-a824-4059-a6b8-a37df410d2ec">


<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
