### PR TITLE
Feat/update manifest

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -24,6 +24,13 @@
   display: none !important;
 }
 
+/* also hides applicant count at top of page at linkedin.com/jobs/collections when it's not in bold */
+
+.job-details-jobs-unified-top-card__primary-description-without-tagline:has(
+    .tvm__text--neutral
+  ):last-child {
+  display: none !important;
+}
 /* bold green text on linkedin.com/jobs/ next to the word promoted */
 
 .job-card-container__footer-item > strong {

--- a/manifest.json
+++ b/manifest.json
@@ -3,37 +3,30 @@
   "name": "Hide LinkedIn Applicants",
   "version": "0.0.10",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
-   "permissions": ["scripting"],
+  "permissions": ["scripting"],
   "icons": {
     "16": "images/hide-emoji-16.png",
     "32": "images/hide-emoji-32.png",
     "48": "images/hide-emoji-48.png",
     "128": "images/hide-emoji-128.png"
-},
-"background": {
+  },
+  "background": {
     "service_worker": "scripts/background.js"
-},
-"web_accessible_resources": [
-  {
-    "resources": ["css/*.css"],
-    "extension_ids": [
-      "pokgcjppglddgaomdkidlbcljngaflcd"
-    ]
-    }
-  ],
-"content_scripts": [
+  },
+  "web_accessible_resources": [
     {
-        "matches": [
-        "*://www.linkedin.com/jobs/*"
-      ],
-      "css": ["css/search.css", "css/view.css"]
+      "resources": ["css/*.css"],
+      "extension_ids": ["pokgcjppglddgaomdkidlbcljngaflcd"]
     }
-],
-  "host_permissions": [
-    "*://www.linkedin.com/jobs/*"
   ],
+  "content_scripts": [
+    {
+      "matches": ["*://www.linkedin.com/jobs/*"],
+      "css": ["css/global.css"]
+    }
+  ],
+  "host_permissions": ["*://www.linkedin.com/jobs/*"],
   "action": {
-      "default_popup": "popup.html"
+    "default_popup": "popup.html"
   }
-
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Applicants",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Hide the number of job applicants for roles on LinkedIn.",
   "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LinkedIn Applicants</h2>
     <p>
-      version: 0.0.10 |
+      version: 0.0.11 |
       <a
         href="https://github.com/garnetred/hide-linkedin-applicants"
         style="color: navy"

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -5,7 +5,6 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     tabUrl &&
     tabUrl.includes("linkedin.com/jobs/")
   ) {
-    console.log(tabUrl, "taburl");
     chrome.scripting.insertCSS({
       target: { tabId: tabId },
       files: ["css/global.css"],

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -5,6 +5,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     tabUrl &&
     tabUrl.includes("linkedin.com/jobs/")
   ) {
+    console.log(tabUrl, "taburl");
     chrome.scripting.insertCSS({
       target: { tabId: tabId },
       files: ["css/global.css"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This is a small change that just hides the applicant count on the linkedin.com/jobs/collections page when it's not in bold. 

<!--- Describe your changes in detail -->

## Background
I noticed that the applicant count was still visible intermittently - I think this was because sometimes the same element is in bold (if there are fewer applicants) and if there are more applicants but less than 100, it's not in bold.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can git clone this branch, load the unpacked extension in your browser while in developer mode, and then navigate to any linkedin.com/jobs route. You shouldn't see any applicant counts. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
