### PR TITLE
Hide bold green text for low applicant count

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -39,10 +39,8 @@
   display: none !important;
 }
 
-job-details-jobs-unified-top-card__primary-description-container
-
 /* bold green text on linkedin.com/jobs/ next to the word promoted */
 
-.job-card-container__footer-item > strong {
+.job-card-container__footer-item:has(strong):has(.tvm__text--positive) {
   display: none !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This PR hides bold green text next to the word promoted on the linkedin.com/jobs page. 
<!--- Describe your changes in detail -->

## Background
I noticed that the green text was visible for me once again and was able to hide it by removing an unused css selector from the global.css file. I also updated the actual css selector to use the :has relational selector. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can load the unpacked extension in developer mode in Chrome. Then you can navigate to any jobs page or individual jobs posting. You shouldn't see any applicant counts. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
